### PR TITLE
fix: allow traces.write.otlphttp.endpoint without grpc-listen flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -1547,12 +1547,12 @@ func parseFlags() (config, error) {
 		}
 	}
 
-	if cfg.traces.enabled && cfg.server.grpcListen == "" {
-		return cfg, fmt.Errorf("-traces.write.endpoint is set to %q but -grpc.listen is not set", cfg.traces.writeOTLPGRPCEndpoint)
+	if cfg.traces.writeOTLPGRPCEndpoint != "" && cfg.server.grpcListen == "" {
+		return cfg, fmt.Errorf("--traces.write.endpoint is set to %q but --grpc.listen is not set", cfg.traces.writeOTLPGRPCEndpoint)
 	}
 
-	if !cfg.traces.enabled && cfg.server.grpcListen != "" {
-		return cfg, fmt.Errorf("-traces.write.endpoint is not set but -grpc.listen is set to %q", cfg.server.grpcListen)
+	if cfg.traces.writeOTLPGRPCEndpoint == "" && cfg.server.grpcListen != "" {
+		return cfg, fmt.Errorf("--traces.write.endpoint is not set but --grpc.listen is set to %q", cfg.server.grpcListen)
 	}
 
 	if rawTLSCipherSuites != "" {


### PR DESCRIPTION
The validation logic incorrectly required --grpc-listen for all traces endpoints. This prevented using --traces.write.otlphttp.endpoint alone, even though OTLP HTTP uses the standard HTTP server (port 8080) and doesn't need gRPC.

- https://github.com/observatorium/api/pull/873